### PR TITLE
add cyclic lifetime param

### DIFF
--- a/peakshaving_analyzer/PSA.py
+++ b/peakshaving_analyzer/PSA.py
@@ -184,7 +184,7 @@ class PeakShavingAnalyzer:
                 commodity="stored_energy",
                 locationalEligibility=pd.Series([1, 0], index=["consumption_site", "grid"]),
                 hasCapacityVariable=True,
-                cyclicLifetime=10000,
+                cyclicLifetime=self.config.storage_cyclic_lifetime,
                 chargeEfficiency=self.storage_charge_efficiency,
                 dischargeEfficiency=self.storage_discharge_efficiency,
                 capacityMax=self.max_storage_size_kwh,

--- a/peakshaving_analyzer/input.py
+++ b/peakshaving_analyzer/input.py
@@ -51,6 +51,7 @@ class Config(IOHandler):
     storage_charge_efficiency: float = 0.95
     storage_discharge_efficiency: float = 0.95
     storage_charge_rate: float = 5
+    storage_cyclic_lifetime: float = 10000
     storage_discharge_rate: float = 5
     inverter_efficiency: float = 0.95
     max_pv_system_size_kwp: float | None = None


### PR DESCRIPTION
add test for storage charging

This adds a twist to use `self.config.storage_cyclic_lifetime` instead of copying all the properties over to self.storage_cyclic_lifetime.

I would recommend to do this for all params which are accessible through self.config.
What do you think?